### PR TITLE
fix(host): Retry on context deadline exceeded

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.9.1 // indirect
+	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/bmatcuk/doublestar/v4 v4.9.1 h1:X8jg9rRZmJd4yRy7ZeNDRnM+T3ZfHv15JiBJ/
 github.com/bmatcuk/doublestar/v4 v4.9.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
+github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
+github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=

--- a/internal/provider/resource_icinga2_host.go
+++ b/internal/provider/resource_icinga2_host.go
@@ -2,9 +2,11 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
+	"github.com/cenkalti/backoff/v5"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -167,6 +169,24 @@ func (r *hostResource) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 
 	hosts, err := r.client.CreateHost(plan.Hostname.ValueString(), plan.Address.ValueString(), "", plan.CheckCommand.ValueString(), vars, templates, groups, plan.Zone.ValueString())
+
+	// Retry on context deadline exceeded
+	if err != nil && errors.Is(err, context.DeadlineExceeded) {
+		checkOperation := func() ([]iapi.HostStruct, error) {
+			hosts, err := r.client.GetHost(plan.Hostname.ValueString())
+			if err != nil {
+				return nil, err
+			}
+			for _, host := range hosts {
+				if host.Name == plan.Hostname.ValueString() {
+					return hosts, nil
+				}
+			}
+			return nil, fmt.Errorf("Host '%s' not found after creation", plan.Hostname.ValueString())
+		}
+		hosts, err = backoff.Retry(ctx, checkOperation, backoff.WithBackOff(backoff.NewExponentialBackOff()))
+	}
+
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating Host",
@@ -241,6 +261,22 @@ func (r *hostResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 	}
 
 	err := r.client.DeleteHost(state.Hostname.ValueString())
+
+	// Retry on context deadline exceeded
+	if err != nil && errors.Is(err, context.DeadlineExceeded) {
+		checkOperation := func() (string, error) {
+			exists, err := r.client.HostExists(state.Hostname.ValueString())
+			if err != nil {
+				return "", err
+			}
+			if exists {
+				return "", fmt.Errorf("Host '%s' still exists after deletion", state.Hostname.ValueString())
+			}
+			return "", nil
+		}
+		_, err = backoff.Retry(ctx, checkOperation, backoff.WithBackOff(backoff.NewExponentialBackOff()))
+	}
+
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Deleting Host",


### PR DESCRIPTION
When hundred of hosts are created or deleted at the same time, the API can be so slow that a context deadline is reached (1 minute). Even if the call has failed on the client, the resource is created or deleted on the infrastructure after a while. At a second run, the plan will fail because the resource already exists on the infrastructure but it's not in the state, or it has been deleted and it's still in the state.

When a context deadline is exceeded, wait for the resource to be created or deleted by retrying with an exponential backoff. Return the underlying error if it's not a context deadline exceeded error.