### PR TITLE
fix(host): Add templates to imports and force recreate

### DIFF
--- a/internal/provider/resource_icinga2_host.go
+++ b/internal/provider/resource_icinga2_host.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -84,6 +85,9 @@ func (r *hostResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 			"templates": schema.ListAttribute{
 				ElementType: types.StringType,
 				Optional:    true,
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.RequiresReplace(),
+				},
 			},
 			"zone": schema.StringAttribute{
 				Optional: true,
@@ -213,6 +217,25 @@ func (r *hostResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 			state.Address = types.StringValue(host.Attrs.Address)
 			state.CheckCommand = types.StringValue(host.Attrs.CheckCommand)
 			state.Zone = types.StringValue(host.Attrs.Zone)
+
+			var templates []string
+			for _, template := range host.Attrs.Templates {
+				if template == host.Name {
+					continue
+				}
+				templates = append(templates, template)
+			}
+
+			if len(templates) > 0 {
+				templateList, diag := types.ListValueFrom(ctx, types.StringType, templates)
+				resp.Diagnostics.Append(diag...)
+				if resp.Diagnostics.HasError() {
+					return
+				}
+				state.Templates = templateList
+			} else {
+				state.Templates = types.ListNull(types.StringType)
+			}
 
 			// Note: We might need to map vars back to state correctly for lists/maps. For simplicity keeping it string mapped to attributes if they existed directly.
 		}

--- a/internal/provider/resource_icinga2_host_test.go
+++ b/internal/provider/resource_icinga2_host_test.go
@@ -127,6 +127,12 @@ func TestAccCreateTemplateHost(t *testing.T) {
 					resource.TestCheckResourceAttr("icinga2_host.tf-4", "templates.1", "az1"),
 				),
 			},
+			{
+				ImportState:             true,
+				ResourceName:            "icinga2_host.tf-4",
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_updated"},
+			},
 		},
 	})
 }


### PR DESCRIPTION
When a host is imported, template are not imported. Templates trigger an in-place update leading to an update not implemented error. This commit forces a re-create when a template is updated, which is expected by Icinga, and also add templates to the host at import to avoid unecessary changes.